### PR TITLE
cflags fno-exceptions

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,8 @@
   'targets': [
     {
       'target_name': 'pHashBinding',
+      'cflags!': [ '-fno-exceptions' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
       'defines': [
         'HAVE_IMAGE_HASH',
         'cimg_verbosity=0',

--- a/lib/phash.js
+++ b/lib/phash.js
@@ -23,15 +23,27 @@
 var pHash = require('../build/Release/pHashBinding');
 
 exports.imageHashSync = function(file) {
-	return pHash.imageHashSync(file);
+    try{
+	   return pHash.imageHashSync(file);
+    }catch(err){
+        throw err;
+    }
 };
 
 exports.imageHash = function(file, cb) {
-	return pHash.imageHash(file, cb);
+    try{
+	   return pHash.imageHash(file, cb);
+    }catch(err){
+        throw err;
+    }	
 };
 
 exports.hammingDistance = function(hasha, hashb) {
-	return pHash.hammingDistance(hasha, hashb);
+    try{
+	   return pHash.hammingDistance(hasha, hashb);
+    }catch(err){
+        throw err;
+    }	
 };
 
 /*
@@ -40,5 +52,9 @@ exports.hammingDistance = function(hasha, hashb) {
 exports.getImageHash = exports.imageHashSync;
 
 exports.getOldHash = function(filePath) {
-	return pHash.oldHash(filePath);
+    try{
+	   return pHash.oldHash(filePath);
+    }catch(err){
+        throw err;
+    }	
 };

--- a/lib/phash.js
+++ b/lib/phash.js
@@ -23,27 +23,15 @@
 var pHash = require('../build/Release/pHashBinding');
 
 exports.imageHashSync = function(file) {
-    try{
-	   return pHash.imageHashSync(file);
-    }catch(err){
-        throw err;
-    }
+    return pHash.imageHashSync(file);
 };
 
 exports.imageHash = function(file, cb) {
-    try{
-	   return pHash.imageHash(file, cb);
-    }catch(err){
-        throw err;
-    }	
+    return pHash.imageHash(file, cb);	
 };
 
 exports.hammingDistance = function(hasha, hashb) {
-    try{
-	   return pHash.hammingDistance(hasha, hashb);
-    }catch(err){
-        throw err;
-    }	
+    pHash.hammingDistance(hasha, hashb);
 };
 
 /*
@@ -52,9 +40,5 @@ exports.hammingDistance = function(hasha, hashb) {
 exports.getImageHash = exports.imageHashSync;
 
 exports.getOldHash = function(filePath) {
-    try{
-	   return pHash.oldHash(filePath);
-    }catch(err){
-        throw err;
-    }	
+    return pHash.oldHash(filePath);	
 };


### PR DESCRIPTION
I added in 'cflags!': [ '-fno-exceptions' ],
      'cflags_cc!': [ '-fno-exceptions' ], to binding.gyp because if I am trying to process images in a queue  and I try to hash an image that is malformed or just not existent or does not have the rights to read for some reason I get something like the following 

[CImg] *** CImgIOException *** [instance(0,0,0,0,0x0,non-shared)] CImg<unsigned char>::load(): Failed to recognize format of file '/Users/bryan/projects/repositories/secondweownit/weownit/public/uploads/images/54ca/54ca0ac949f1d8c972000005/1223cbTHUMB-chagrin-falls-patriotic-debate.jpg'.
node(7178,0x1055e1000) malloc: *** error for object 0x101040a00: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug

after which my process queue shuts down and I can't keep processing the next images that do work. 

If however I can catch the exceptions my queue can register the errors and keep merrily chugging along. 

It's not necessarily the best solution, so you may want to do other things to allow processing of errors. 

Thanks for your work on this. 
