### PR TITLE
Fix build issue

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -34,7 +34,6 @@
 	  {
 	    'ccflags': [
       	      '-mmacosx-version-min=10.7',
-      	      '<!@(pkg-config --cflags pHash)',
       	      '-std=c++11',
       	      '-stdlib=libc++'
 	    ]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "phash",
   "version": "0.0.6",
   "description": "Bindings for node.js to pHash",
-  "main": "src/phash.js",
+  "main": "lib/phash.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/aaronm67/node-phash.git"

--- a/src/phash.cpp
+++ b/src/phash.cpp
@@ -24,7 +24,7 @@
 #include <v8.h>
 #include <node.h>
 #include <nan.h>
-#include "pHash.h"
+#include "../deps/pHash/pHash.h"
 #include <sstream>
 #include <fstream>
 #include <cstdio>


### PR DESCRIPTION
This fixed `npm install phash` build issues on my Ubuntu and MacOs.

Tested by installing in a separate module and also running `npm test`.
